### PR TITLE
fix: build errors under Linux

### DIFF
--- a/ExpGame.pro
+++ b/ExpGame.pro
@@ -10,7 +10,7 @@ greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 
 TARGET = ExpGame
 TEMPLATE = app
-
+QMAKE_CXXFLAGS += -std=c++11
 
 SOURCES += main.cpp\
         gui/mainwindow.cpp \

--- a/gui/qgameoverwindow.cpp
+++ b/gui/qgameoverwindow.cpp
@@ -1,7 +1,7 @@
 #include "qgameoverwindow.h"
 #include "qresetbutton.h"
 
-#include <QVboxLayout>
+#include <QVBoxLayout>
 #include <QLabel>
 #include <QDebug>
 #include <QResizeEvent>


### PR DESCRIPTION
Hi.
- compilation even under Qt4 with C++11 ready compiler;
- under Linux - header names is case sensitive.
  PS: thank you for awesome game.
